### PR TITLE
Fix compatibility and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: ruby
+services:
+  - redis
 rvm:
-  - 1.9.3
   - jruby-19mode
   - rbx-19mode
+  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.1.1
 env:
   matrix:
-    - SIDEKIQ_VERSION="~> 2.5.0"
+    - SIDEKIQ_VERSION="~> 2.6.0"
     - SIDEKIQ_VERSION="~> 2.17.0"
     - SIDEKIQ_VERSION="~> 3.0.0"
+matrix:
+  allow_failures:
+    - rvm: jruby-19mode
+    - rvm: rbx-19mode
 branches:
   only:
     - master
@@ -18,7 +24,3 @@ notifications:
   email:
     recipients:
       - pablo@pablocantero.com
-matrix:
-  allow_failures:
-    - rvm: jruby-19mode
-    - rvm: rbx-19mode

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -54,7 +54,9 @@ module Sidekiq::Statsd
           queue_name = msg['queue']
           sidekiq_queue = Sidekiq::Queue.new(queue_name)
           b.gauge prefix('queues', queue_name, 'enqueued'), sidekiq_queue.size
-          b.gauge prefix('queues', queue_name, 'latency'), sidekiq_queue.latency
+          if sidekiq_queue.respond_to?(:latency)
+            b.gauge prefix('queues', queue_name, 'latency'), sidekiq_queue.latency
+          end
         end
       end
     end

--- a/sidekiq-statsd.gemspec
+++ b/sidekiq-statsd.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport"
-  gem.add_dependency "sidekiq", ">= 2.5"
+  gem.add_dependency "sidekiq", ">= 2.6"
   gem.add_dependency "statsd-ruby", ">= 1.1.0"
 end


### PR DESCRIPTION
- Bump Sidekiq requirement to 2.6
- Make latency gauge optional (works since 2.12)
- Add redis service to travis config
