### PR TITLE
Demodulize worker names to have valid StatsD metrics.

### DIFF
--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -34,12 +34,13 @@ module Sidekiq::Statsd
     def call worker, msg, queue
       @statsd.batch do |b|
         begin
-          b.time prefix(worker.class.name, 'processing_time') do
+          worker_name = worker.class.name.gsub("::", ".")
+          b.time prefix(worker_name, 'processing_time') do
             yield
           end
-          b.increment prefix(worker.class.name, 'success')
+          b.increment prefix(worker_name, 'success')
         rescue => e
-          b.increment prefix(worker.class.name, 'failure')
+          b.increment prefix(worker_name, 'failure')
           raise e
         ensure
           # Queue sizes


### PR DESCRIPTION
When having workers inside namespaces the "::" in the worker name will create invalid metric names.

The following was found on our StatsD logs:

```
DEBUG: Bad line:  in msg "production.worker.Cassandra::NotificationMapWorker.success:1|c|@0.1"
```
