### PR TITLE
optionally avoid Sidekiq::Stats#fetch_stats!

### DIFF
--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -25,7 +25,7 @@ module Sidekiq::Statsd
                    sidekiq_stats:  true }.merge options
 
       @statsd = options[:statsd] || ::Statsd.new(@options[:host], @options[:port])
-      @sidekiq_stats = Sidekiq::Stats.new
+      @sidekiq_stats = Sidekiq::Stats.new if @options[:sidekiq_stats]
     end
 
     ##

--- a/spec/sidekiq/statsd/server_middleware_spec.rb
+++ b/spec/sidekiq/statsd/server_middleware_spec.rb
@@ -52,6 +52,12 @@ describe Sidekiq::Statsd::ServerMiddleware do
   context 'without global sidekiq stats' do
     let(:sidekiq_stats) { double }
 
+    it "doesn't initialze a Sidekiq::Stats instance" do
+      # Sidekiq::Stats.new calls fetch_stats!, which makes redis calls
+      expect(described_class.new(sidekiq_stats: false).instance_variable_get(:@sidekiq_stats))
+        .to be_nil
+    end
+
     it "doesn't gauge sidekiq stats" do
       Sidekiq::Stats.stub(:new).and_return(sidekiq_stats)
 


### PR DESCRIPTION
https://github.com/phstc/sidekiq-statsd/pull/9 adds the option to not report global sidekiq stats, but still initializes a `Sidekiq::Stats` instance which [makes the calls to redis](https://github.com/mperham/sidekiq/blob/985706f181e3bf67b1b351952379d6ea27e7ceac/lib/sidekiq/api.rb#L7). The `Sidekiq::Stats` instance should only be initialized if the `sidekiq_stats` option is `true`.