### PR TITLE
Allow for drop-in replacements of statsd-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Sidekiq::Statsd is tested against MRI 1.9.3.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add these lines to your application's Gemfile:
 
+    gem "statsd-ruby"
     gem "sidekiq-statsd"
 
 And then execute:

--- a/sidekiq-statsd.gemspec
+++ b/sidekiq-statsd.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activesupport"
   gem.add_dependency "sidekiq", ">= 2.6"
-  gem.add_dependency "statsd-ruby", ">= 1.1.0"
 end


### PR DESCRIPTION
We use `dogstatsd-ruby` as a drop-in replacement for the regular `statsd-ruby`. Unfortunately the latter is hardcoded in this gem. 

This pull request extracts the hard dependency and updates the README to add the regular `statsd-ruby` as an additional dependency.
