### PR TITLE
Allow for drop-in replacements of statsd-ruby - take 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Sidekiq::Statsd is tested against [several Ruby versions](.travis.yml#L4).
 
 Add these lines to your application's Gemfile:
 
-    gem "statsd-ruby" # or dogstatsd-ruby for Datadog
+    gem "statsd-ruby"
+    # or if you are using Datadog
+    # gem "dogstatsd-ruby"
     gem "sidekiq-statsd"
 
 And then execute:
@@ -30,14 +32,16 @@ In a Rails initializer or wherever you've configured Sidekiq, add
 Sidekiq::Statsd to your server middleware:
 
 ```ruby
+require 'statsd'
+statsd = Statsd.new('localhost', 8125)
+
+# or if you are using Datadog
+# require 'datadog/statsd'
+# statsd = Datadog::Statsd.new('localhost', 8125)
+
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add Sidekiq::Statsd::ServerMiddleware, env: "production", prefix: "worker", host: "localhost", port: 8125
-
-    # or if you use Datadog
-    # require 'datadog/statsd'
-    # statsd = Datadog::Statsd.new('localhost', 8125)
-    # chain.add Sidekiq::Statsd::ServerMiddleware, env: "production", prefix: "worker", statsd: statsd
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: "production", prefix: "worker", statsd: statsd
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Sidekiq::Statsd to your server middleware:
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sidekiq::Statsd::ServerMiddleware, env: "production", prefix: "worker", host: "localhost", port: 8125
+
+    # or if you use Datadog
+    # require 'datadog/statsd'
+    # statsd = Datadog::Statsd.new('localhost', 8125)
+    # chain.add Sidekiq::Statsd::ServerMiddleware, env: "production", prefix: "worker", statsd: statsd
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Sidekiq::Statsd is tested against [several Ruby versions](.travis.yml#L4).
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add these lines to your application's Gemfile:
 
+    gem "statsd-ruby" # or dogstatsd-ruby for Datadog
     gem "sidekiq-statsd"
 
 And then execute:

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -9,11 +9,9 @@ module Sidekiq::Statsd
     # Initializes the middleware with options.
     #
     # @param [Hash] options The options to initialize the StatsD client.
-    # @option options [Statsd] :statsd Existing statsd client.
+    # @option options [Statsd] :statsd Existing StatsD client.
     # @option options [String] :env ("production") The env to segment the metric key (e.g. env.prefix.worker_name.success|failure).
     # @option options [String] :prefix ("worker") The prefix to segment the metric key (e.g. env.prefix.worker_name.success|failure).
-    # @option options [String] :host ("localhost") The StatsD host.
-    # @option options [String] :port ("8125") The StatsD port.
     # @option options [String] :sidekiq_stats ("true") Send Sidekiq global stats e.g. total enqueued, processed and failed.
     def initialize(options = {})
       @options = { env:            'production',
@@ -22,7 +20,7 @@ module Sidekiq::Statsd
                    port:           8125,
                    sidekiq_stats:  true }.merge options
 
-      @statsd = options[:statsd] || initialize_statsd
+      @statsd = options[:statsd] || raise("A StatsD client must be provided")
       @sidekiq_stats = Sidekiq::Stats.new if @options[:sidekiq_stats]
     end
 
@@ -72,16 +70,6 @@ module Sidekiq::Statsd
     end
 
     private
-
-    def initialize_statsd
-      begin
-        require 'statsd'
-      rescue LoadError
-        fail "Please add gem 'statsd-ruby' to your Gemfile"
-      end
-
-      ::Statsd.new(@options[:host], @options[:port])
-    end
 
     ##
     # Converts args passed to it into a metric name with prefix.

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-require 'statsd'
-
 module Sidekiq::Statsd
   ##
   # Sidekiq StatsD is a middleware to track worker execution metrics through statsd.
@@ -24,7 +22,7 @@ module Sidekiq::Statsd
                    port:           8125,
                    sidekiq_stats:  true }.merge options
 
-      @statsd = options[:statsd] || ::Statsd.new(@options[:host], @options[:port])
+      @statsd = options[:statsd] || initialize_statsd
       @sidekiq_stats = Sidekiq::Stats.new if @options[:sidekiq_stats]
     end
 
@@ -74,6 +72,16 @@ module Sidekiq::Statsd
     end
 
     private
+
+    def initialize_statsd
+      begin
+        require 'statsd'
+      rescue LoadError
+        fail "Please add gem 'statsd-ruby' to your Gemfile"
+      end
+
+      ::Statsd.new(@options[:host], @options[:port])
+    end
 
     ##
     # Converts args passed to it into a metric name with prefix.

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -14,11 +14,7 @@ module Sidekiq::Statsd
     # @option options [String] :prefix ("worker") The prefix to segment the metric key (e.g. env.prefix.worker_name.success|failure).
     # @option options [String] :sidekiq_stats ("true") Send Sidekiq global stats e.g. total enqueued, processed and failed.
     def initialize(options = {})
-      @options = { env:            'production',
-                   prefix:         'worker',
-                   host:           'localhost',
-                   port:           8125,
-                   sidekiq_stats:  true }.merge options
+      @options = { env: 'production', prefix: 'worker', sidekiq_stats:  true }.merge options
 
       @statsd = options[:statsd] || raise("A StatsD client must be provided")
       @sidekiq_stats = Sidekiq::Stats.new if @options[:sidekiq_stats]

--- a/lib/sidekiq/statsd/version.rb
+++ b/lib/sidekiq/statsd/version.rb
@@ -1,6 +1,6 @@
 module Sidekiq
   module Statsd
-    VERSION = '1.0.0'
+    VERSION = '2.0.0'
   end
 end
 

--- a/sidekiq-statsd.gemspec
+++ b/sidekiq-statsd.gemspec
@@ -18,8 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport"
-  gem.add_dependency "sidekiq", ">= 2.7"
-  gem.add_dependency "statsd-ruby", ">= 1.1.0"
-
-  gem.required_ruby_version = '>= 2.4.0'
+  gem.add_dependency "sidekiq", ">= 2.6"
 end

--- a/sidekiq-statsd.gemspec
+++ b/sidekiq-statsd.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport"
-  gem.add_dependency "sidekiq", ">= 2.6"
+  gem.add_dependency "sidekiq", ">= 2.7"
+
+  gem.required_ruby_version = '>= 2.4.0'
 end

--- a/spec/sidekiq/statsd/server_middleware_spec.rb
+++ b/spec/sidekiq/statsd/server_middleware_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
 describe Sidekiq::Statsd::ServerMiddleware do
-  subject(:middleware) { described_class.new }
+  subject(:middleware) { described_class.new(statsd: client) }
 
   let(:worker) { double "Dummy worker" }
   let(:msg)    { { 'queue' => 'mailer' } }
   let(:queue)  { nil }
-  let(:client) { double(::Statsd).as_null_object }
+  let(:client) { double('StatsD').as_null_object }
 
   let(:worker_name) { worker.class.name.gsub("::", ".") }
 
@@ -14,28 +14,15 @@ describe Sidekiq::Statsd::ServerMiddleware do
   let(:broken_job) { ->{ raise 'error' } }
 
   before do
-    allow_any_instance_of(::Statsd).to receive(:batch).and_yield(client)
+    allow(client).to receive(:batch).and_yield(client)
   end
 
-  it "doesn't initialize a ::Statsd client if passed-in" do
-    expect(::Statsd)
-      .to receive(:new)
-      .never
-
-    described_class.new(statsd: client)
+  it "raises error if no statsd supplied" do
+    expect { described_class.new }.to raise_error("A StatsD client must be provided")
   end
 
   context "with customised options" do
     describe "#new" do
-      it "uses the custom statsd host and port" do
-        expect(::Statsd)
-          .to receive(:new)
-          .with('example.com', 8126)
-          .once
-
-        described_class.new(host: 'example.com', port: 8126)
-      end
-
       it "uses the custom metric name prefix options" do
         expect(client)
           .to receive(:time)
@@ -44,31 +31,27 @@ describe Sidekiq::Statsd::ServerMiddleware do
           .and_yield
 
         described_class
-          .new(env: 'development', prefix: 'application.sidekiq')
+          .new(statsd: client, env: 'development', prefix: 'application.sidekiq')
           .call(worker, msg, queue, &clean_job)
       end
     end
   end
 
   context 'without global sidekiq stats' do
-    let(:sidekiq_stats) { double }
-
     it "doesn't initialze a Sidekiq::Stats instance" do
       # Sidekiq::Stats.new calls fetch_stats!, which makes redis calls
-      expect(described_class.new(sidekiq_stats: false).instance_variable_get(:@sidekiq_stats))
+      expect(described_class.new(statsd: client, sidekiq_stats: false).instance_variable_get(:@sidekiq_stats))
         .to be_nil
     end
 
     it "doesn't gauge sidekiq stats" do
-      allow(Sidekiq::Stats).to receive(:new) { sidekiq_stats }
-
-      expect(sidekiq_stats).not_to receive(:enqueued)
-      expect(sidekiq_stats).not_to receive(:retry_size)
-      expect(sidekiq_stats).not_to receive(:processed)
-      expect(sidekiq_stats).not_to receive(:failed)
+      expect(client).not_to receive(:enqueued)
+      expect(client).not_to receive(:retry_size)
+      expect(client).not_to receive(:processed)
+      expect(client).not_to receive(:failed)
 
       described_class
-        .new(sidekiq_stats: false)
+        .new(statsd: client, sidekiq_stats: false)
         .call(worker, msg, queue, &clean_job)
     end
   end


### PR DESCRIPTION
This is a continuation of #11.

Adding support for customizing the StatsD client. 