### PR TITLE
Fix not using current values for global stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ rvm:
   - 2.5.0
   - 2.6.0
 env:
-  - SIDEKIQ_VERSION="~> 2.7.0"
-  - SIDEKIQ_VERSION="~> 3.0.0"
+  - SIDEKIQ_VERSION="~> 3.3.1"
   - SIDEKIQ_VERSION="~> 4.0.0"
   - SIDEKIQ_VERSION="~> 5.0.0"
   - SIDEKIQ_VERSION="~> 6.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.0.1
+
+* Fix stuck global stats (retries, processed, etc.)
+
+# 2.0.0
+
+* BREAKING: drop host/port options
+* Add support for custom statsd client
+
 # 1.0.0
 
 * Pin minimum Ruby version to 2.4

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -17,7 +17,6 @@ module Sidekiq::Statsd
       @options = { env: 'production', prefix: 'worker', sidekiq_stats:  true }.merge options
 
       @statsd = options[:statsd] || raise("A StatsD client must be provided")
-      @sidekiq_stats = Sidekiq::Stats.new if @options[:sidekiq_stats]
     end
 
     ##
@@ -42,16 +41,15 @@ module Sidekiq::Statsd
           raise e
         ensure
           if @options[:sidekiq_stats]
+            sidekiq_stats = Sidekiq::Stats.new
+
             # Queue sizes
-            b.gauge prefix('enqueued'), @sidekiq_stats.enqueued
-            if @sidekiq_stats.respond_to?(:retry_size)
-              # 2.6.0 doesn't have `retry_size`
-              b.gauge prefix('retry_set_size'), @sidekiq_stats.retry_size
-            end
+            b.gauge prefix('enqueued'), sidekiq_stats.enqueued
+            b.gauge prefix('retry_set_size'), sidekiq_stats.retry_size
 
             # All-time counts
-            b.gauge prefix('processed'),  @sidekiq_stats.processed
-            b.gauge prefix('failed'),     @sidekiq_stats.failed
+            b.gauge prefix('processed'), sidekiq_stats.processed
+            b.gauge prefix('failed'), sidekiq_stats.failed
           end
 
           # Queue metrics

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -40,30 +40,34 @@ module Sidekiq::Statsd
           b.increment prefix(worker_name, 'failure')
           raise e
         ensure
-          if @options[:sidekiq_stats]
-            sidekiq_stats = Sidekiq::Stats.new
-
-            # Queue sizes
-            b.gauge prefix('enqueued'), sidekiq_stats.enqueued
-            b.gauge prefix('retry_set_size'), sidekiq_stats.retry_size
-
-            # All-time counts
-            b.gauge prefix('processed'), sidekiq_stats.processed
-            b.gauge prefix('failed'), sidekiq_stats.failed
-          end
-
-          # Queue metrics
-          queue_name = msg['queue']
-          sidekiq_queue = Sidekiq::Queue.new(queue_name)
-          b.gauge prefix('queues', queue_name, 'enqueued'), sidekiq_queue.size
-          if sidekiq_queue.respond_to?(:latency)
-            b.gauge prefix('queues', queue_name, 'latency'), sidekiq_queue.latency
-          end
+          report_global_stats(b) if @options[:sidekiq_stats]
+          report_queue_stats(b, msg['queue'])
         end
       end
     end
 
     private
+
+    def report_global_stats(statsd)
+      sidekiq_stats = Sidekiq::Stats.new
+
+      # Queue sizes
+      statsd.gauge prefix('enqueued'), sidekiq_stats.enqueued
+      statsd.gauge prefix('retry_set_size'), sidekiq_stats.retry_size
+
+      # All-time counts
+      statsd.gauge prefix('processed'), sidekiq_stats.processed
+      statsd.gauge prefix('failed'), sidekiq_stats.failed
+    end
+
+    def report_queue_stats(statsd, queue_name)
+      sidekiq_queue = Sidekiq::Queue.new(queue_name)
+      statsd.gauge prefix('queues', queue_name, 'enqueued'), sidekiq_queue.size
+
+      if sidekiq_queue.respond_to?(:latency)
+        statsd.gauge prefix('queues', queue_name, 'latency'), sidekiq_queue.latency
+      end
+    end
 
     ##
     # Converts args passed to it into a metric name with prefix.

--- a/lib/sidekiq/statsd/version.rb
+++ b/lib/sidekiq/statsd/version.rb
@@ -1,6 +1,6 @@
 module Sidekiq
   module Statsd
-    VERSION = '2.0.0'
+    VERSION = '2.0.1'
   end
 end
 

--- a/sidekiq-statsd.gemspec
+++ b/sidekiq-statsd.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "activesupport"
-  gem.add_dependency "sidekiq", ">= 2.7"
+  gem.add_dependency "sidekiq", ">= 3.3.1"
 
   gem.required_ruby_version = '>= 2.4.0'
 end

--- a/spec/sidekiq/statsd/server_middleware_spec.rb
+++ b/spec/sidekiq/statsd/server_middleware_spec.rb
@@ -38,10 +38,10 @@ describe Sidekiq::Statsd::ServerMiddleware do
   end
 
   context 'without global sidekiq stats' do
-    it "doesn't initialze a Sidekiq::Stats instance" do
+    it "doesn't initialize a Sidekiq::Stats instance" do
       # Sidekiq::Stats.new calls fetch_stats!, which makes redis calls
-      expect(described_class.new(statsd: client, sidekiq_stats: false).instance_variable_get(:@sidekiq_stats))
-        .to be_nil
+      expect(Sidekiq::Stats).not_to receive(:new)
+      described_class.new(statsd: client, sidekiq_stats: false)
     end
 
     it "doesn't gauge sidekiq stats" do


### PR DESCRIPTION
Since Sidekiq 3.3.1 the Sidekiq::Stats class memoises the values it
fetches on initialization. This fixes the middleware to ensure we
fetch the latest stats before reporting them. Pinning above 3.3.0 also
means we can rely on the presence of the 'retry_set' metric.

https://github.com/mperham/sidekiq/commit/8f36e26453318ac0262363eeac86cae2f60cfb85#diff-3c240ab72e022d1aea4eb0c148de1299