### PR TITLE
Report overall worker stats (by queue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0
+
+* Report stats across all workers (processing, runtime)
+
 # 2.0.1
 
 * Fix stuck global stats (retries, processed, etc.)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 [![Build Status](https://secure.travis-ci.org/phstc/sidekiq-statsd.png)](http://travis-ci.org/phstc/sidekiq-statsd)
 [![Dependency Status](https://gemnasium.com/phstc/sidekiq-statsd.png)](https://gemnasium.com/phstc/sidekiq-statsd)
 
-Sidekiq StatsD is a [Sidekiq server middleware](https://github.com/mperham/sidekiq/wiki/Middleware) to send [Sidekiq worker metrics](https://github.com/mperham/sidekiq/wiki/API#wiki-stats) through [statsd](https://github.com/reinh/statsd).
+Sidekiq StatsD is a [Sidekiq server middleware](https://github.com/mperham/sidekiq/wiki/Middleware) to send Sidekiq metrics through [statsd](https://github.com/reinh/statsd):
+
+  - [global metrics](https://github.com/mperham/sidekiq/wiki/API#wiki-stats)
+  - [queue metrics](https://github.com/mperham/sidekiq/wiki/API#queue)
+  - [worker metrics](https://github.com/mperham/sidekiq/wiki/API#workers) (`processing`, `runtime`)
+  - job metrics (`processing_time` and `success` / `failure`)
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,11 @@ end
 
 ```ruby
 # @param [Hash] options The options to initialize the StatsD client.
-# @option options [Statsd] :statsd Existing statsd client to use.
+# @option options [Statsd] :statsd Existing [statsd client](https://github.com/github/statsd-ruby) to use.
 # @option options [String] :env ("production") The env to segment the metric key (e.g. env.prefix.worker_name.success|failure).
 # @option options [String] :prefix ("worker") The prefix to segment the metric key (e.g. env.prefix.worker_name.success|failure).
-# @option options [String] :host ("localhost") The StatsD host.
-# @option options [String] :port ("8125") The StatsD port.
 # @option options [String] :sidekiq_stats ("true") Send Sidekiq global stats e.g. total enqueued, processed and failed.
 ```
-
-If you have a [statsd instance](https://github.com/github/statsd-ruby) you can pass it through the `:statsd` option. If not you can pass the `:host` and `:port` to connect to statsd.
 
 ## Contributing
 

--- a/lib/sidekiq/statsd/server_middleware.rb
+++ b/lib/sidekiq/statsd/server_middleware.rb
@@ -63,10 +63,7 @@ module Sidekiq::Statsd
     def report_queue_stats(statsd, queue_name)
       sidekiq_queue = Sidekiq::Queue.new(queue_name)
       statsd.gauge prefix('queues', queue_name, 'enqueued'), sidekiq_queue.size
-
-      if sidekiq_queue.respond_to?(:latency)
-        statsd.gauge prefix('queues', queue_name, 'latency'), sidekiq_queue.latency
-      end
+      statsd.gauge prefix('queues', queue_name, 'latency'), sidekiq_queue.latency
     end
 
     ##
@@ -78,3 +75,4 @@ module Sidekiq::Statsd
     end
   end # ServerMiddleware
 end # Sidekiq
+

--- a/lib/sidekiq/statsd/version.rb
+++ b/lib/sidekiq/statsd/version.rb
@@ -1,6 +1,6 @@
 module Sidekiq
   module Statsd
-    VERSION = '2.0.1'
+    VERSION = '2.1.0'
   end
 end
 

--- a/spec/sidekiq/statsd/server_middleware_spec.rb
+++ b/spec/sidekiq/statsd/server_middleware_spec.rb
@@ -49,17 +49,6 @@ describe Sidekiq::Statsd::ServerMiddleware do
       expect(Sidekiq::Workers).not_to receive(:new)
       described_class.new(statsd: client, sidekiq_stats: false)
     end
-
-    it "doesn't gauge sidekiq stats" do
-      expect(client).not_to receive(:enqueued)
-      expect(client).not_to receive(:retry_size)
-      expect(client).not_to receive(:processed)
-      expect(client).not_to receive(:failed)
-
-      described_class
-        .new(statsd: client, sidekiq_stats: false)
-        .call(worker, msg, queue, &clean_job)
-    end
   end
 
   context "with successful execution" do

--- a/spec/sidekiq/statsd/server_middleware_spec.rb
+++ b/spec/sidekiq/statsd/server_middleware_spec.rb
@@ -39,8 +39,14 @@ describe Sidekiq::Statsd::ServerMiddleware do
 
   context 'without global sidekiq stats' do
     it "doesn't initialize a Sidekiq::Stats instance" do
-      # Sidekiq::Stats.new calls fetch_stats!, which makes redis calls
+      # Sidekiq::Stats.new makes redis calls
       expect(Sidekiq::Stats).not_to receive(:new)
+      described_class.new(statsd: client, sidekiq_stats: false)
+    end
+
+    it "doesn't initialize a Sidekiq::Workers instance" do
+      # Sidekiq::Workers.new makes redis calls
+      expect(Sidekiq::Workers).not_to receive(:new)
       described_class.new(statsd: client, sidekiq_stats: false)
     end
 

--- a/spec/support/shared_examples_for_a_resilient_gauge_reporter.rb
+++ b/spec/support/shared_examples_for_a_resilient_gauge_reporter.rb
@@ -1,10 +1,16 @@
+require 'active_support/testing/time_helpers'
+
 shared_examples "a resilient gauge reporter" do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:sidekiq_stats) { double(enqueued: 1, processed: 2, failed: 3, retry_size: 4) }
+  let!(:sidekiq_workers) { [["pid", "tid", { "queue" => "my_queue", "run_at" => Time.now.to_i }]] }
   let(:queue_stats)   { double(size: 3, latency: 4.2) }
 
   before do
     allow(Sidekiq::Stats).to receive(:new) { sidekiq_stats }
     allow(Sidekiq::Queue).to receive(:new).with('mailer') { queue_stats }
+    allow(Sidekiq::Workers).to receive(:new) { sidekiq_workers }
   end
 
   it "gauges enqueued jobs" do
@@ -56,6 +62,26 @@ shared_examples "a resilient gauge reporter" do
     expect(client)
       .to receive(:gauge)
       .with("production.worker.queues.mailer.latency", 4.2)
+      .once
+
+    middleware.call(worker, msg, queue, &job)
+  end
+
+  it "gauges precessing jobs" do
+    expect(client)
+      .to receive(:gauge)
+      .with("production.worker.queues.my_queue.processing", 1)
+      .once
+
+    middleware.call(worker, msg, queue, &job)
+  end
+
+  it "gauges job runtime" do
+    travel_to 5.minutes.from_now
+
+    expect(client)
+      .to receive(:gauge)
+      .with("production.worker.queues.my_queue.runtime", 300)
       .once
 
     middleware.call(worker, msg, queue, &job)


### PR DESCRIPTION
This adds two new gauge stats ('processing' and 'runtime') using the
Sidekiq::Workers API, grouped by queue. In order to avoid excess Redis
calls, these stats can be disabled using the existing `sidekiq_stats`
option, which is helpful if there many jobs being processed.

In many cases the set of Sidekiq::Workers will be empty ([]), but these
stats will be useful when one worker is 'stuck' and others continue to
process jobs. Previously, it was necessary to open the Sidekiq UI and
visually scan for stuck workers.

Please see the commits for more details.